### PR TITLE
Add redirect for the old English version

### DIFF
--- a/index_en.html
+++ b/index_en.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="1;url=https://w3c.github.io/danmaku/" />


### PR DESCRIPTION
Not sure why the redirect was removed in https://github.com/w3c/danmaku/commit/7150ace0cfc709f998837e5d50186b86f27a207b#diff-c1977251e2ff87260607e75fc1c1b751

The old `index_en.html` was referenced in various places. I think we should add it back.